### PR TITLE
iOS: Fix bug where file paths containing whitespace cannot be opened

### DIFF
--- a/ios/Classes/FlutterPluginPdfViewerPlugin.m
+++ b/ios/Classes/FlutterPluginPdfViewerPlugin.m
@@ -1,7 +1,6 @@
 #import "FlutterPluginPdfViewerPlugin.h"
 
 static NSString* const kDirectory = @"FlutterPluginPdfViewer";
-static NSString* const kFilePath = @"file:///";
 static NSString* kFileName = @"";
 
 @implementation FlutterPluginPdfViewerPlugin
@@ -31,14 +30,10 @@ static NSString* kFileName = @"";
 
 -(NSString *)getNumberOfPages:(NSString *)url
 {
-    NSURL * sourcePDFUrl;
-    if([url containsString:kFilePath]){
-        sourcePDFUrl = [NSURL URLWithString:url];
-    }else{
-        sourcePDFUrl = [NSURL URLWithString:[kFilePath stringByAppendingString:url]];
-    }
+    NSURL * sourcePDFUrl = [[NSURL alloc]] initFileURLWithPath:url
     CGPDFDocumentRef SourcePDFDocument = CGPDFDocumentCreateWithURL((__bridge CFURLRef)sourcePDFUrl);
     size_t numberOfPages = CGPDFDocumentGetNumberOfPages(SourcePDFDocument);
+    CGPDFDocumentRelease(sourcePDFDocument);
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
     NSString *temporaryDirectory = [paths objectAtIndex:0];
     NSString *filePathAndDirectory = [temporaryDirectory stringByAppendingPathComponent:kDirectory];
@@ -68,12 +63,7 @@ static NSString* kFileName = @"";
 
 -(NSString*)getPage:(NSString *)url ofPage:(size_t)pageNumber
 {
-    NSURL * sourcePDFUrl;
-    if([url containsString:kFilePath]){
-        sourcePDFUrl = [NSURL URLWithString:url];
-    }else{
-        sourcePDFUrl = [NSURL URLWithString:[kFilePath stringByAppendingString:url]];
-    }
+    NSURL * sourcePDFUrl = [[NSURL alloc] initFileURLWithPath:url];
     CGPDFDocumentRef SourcePDFDocument = CGPDFDocumentCreateWithURL((__bridge CFURLRef)sourcePDFUrl);
     size_t numberOfPages = CGPDFDocumentGetNumberOfPages(SourcePDFDocument);
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
@@ -93,11 +83,11 @@ static NSString* kFileName = @"";
         NSLog(@"Create directory error: %@", error);
         return nil;
     }
-    CGPDFPageRef SourcePDFPage = CGPDFDocumentGetPage(SourcePDFDocument, pageNumber);
-    CGPDFPageRetain(SourcePDFPage);
+    CGPDFPageRef sourcePDFPage = CGPDFDocumentGetPage(sourcePDFDocument, pageNumber);
+    CGPDFPageRetain(sourcePDFPage);
     NSString *relativeOutputFilePath = [NSString stringWithFormat:@"%@/%@-%d.png", kDirectory, kFileName, (int)pageNumber];
     NSString *imageFilePath = [temporaryDirectory stringByAppendingPathComponent:relativeOutputFilePath];
-    CGRect sourceRect = CGPDFPageGetBoxRect(SourcePDFPage, kCGPDFMediaBox);
+    CGRect sourceRect = CGPDFPageGetBoxRect(sourcePDFPage, kCGPDFMediaBox);
     UIGraphicsBeginPDFContextToFile(imageFilePath, sourceRect, nil);
     // Calculate resolution
     // Set DPI to 300
@@ -115,11 +105,13 @@ static NSString* kFileName = @"";
     CGContextTranslateCTM(currentContext, 0.0, height);
     CGContextScaleCTM(currentContext, dpi, -dpi);
     CGContextSaveGState(currentContext);
-    CGContextDrawPDFPage (currentContext, SourcePDFPage);
+    CGContextDrawPDFPage (currentContext, sourcePDFPage);
     CGContextRestoreGState(currentContext);
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     [UIImagePNGRepresentation(image) writeToFile: imageFilePath atomically:YES];
+    CGPDFPageRelease(sourcePDFPage);
+    CGPDFDocumentRelease(sourcePDFDocument);
     return imageFilePath;
 }
 


### PR DESCRIPTION
Refer to pdf_viewer PR #67